### PR TITLE
Support to replace groups

### DIFF
--- a/src/modrewrite.js
+++ b/src/modrewrite.js
@@ -60,7 +60,7 @@ module.exports = function(rules) {
           return rewrite.last;
         } else if(rewrite.regex.test(req.url)) {
           res.setHeader('Location', location);
-          req.url = rewrite.replace;
+          req.url = req.url.replace(rewrite.regex, rewrite.replace);
           return rewrite.last;
         }
 


### PR DESCRIPTION
We have the need to strip elements from urls:

/test/a --> /a

Therefore we need to be able to replace groups in expressions:

 '^/test/(.*)$ /$1'

This change makes that possible.
