### PR TITLE
Do not skip if referer is the same as request

### DIFF
--- a/src/modrewrite.js
+++ b/src/modrewrite.js
@@ -62,12 +62,12 @@ module.exports = function(rules, normalize) {
     // have an HTTP referer. We only normalize path which are assets
     if(typeof req.headers.referer !== 'undefined') {
       var referersPath = url.parse(req.headers.referer).path;
-      if(req.url === referersPath) {
-        next();
-        return;
-      }
       if(normalize) {
         if(isNormalizable(req.url)) {
+          if(req.url === referersPath) {
+            next();
+            return;
+          }
           normalizeUrl(req, referersPath);
         }
       }


### PR DESCRIPTION
When refreshing a page that is rewritten, modRewrite would skip handling because the referer is the same as the requested url.

I don't know why exactly you skip handling on referer loops, so i've moved it past isNormalizable check. It should not break asset paths, but it fixes my condition.
