### PR TITLE
fix query parameter nesting

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  */
 
 var url = require('url')
-  , querystring = require('querystring')
+  , qs = require('qs')
   , httpReq = require('http').request
   , httpsReq = require('https').request
   , defaultVia = '1.1 ' + require('os').hostname();
@@ -113,7 +113,7 @@ module.exports = function(rules) {
     // Add to query object
     var queryValue = querySyntax.exec(req.url);
     if(queryValue) {
-      req.params = req.query = querystring.parse(queryValue[1]);
+      req.params = req.query = qs.parse(queryValue[1]);
     }
 
     if(callNext) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "url": "https://github.com/tinganho/connect-modrewrite/blob/master/LICENSE-MIT"
     }
   ],
+  "dependencies": {
+    "qs": "^0.6.6"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.8.0",
     "grunt": "~0.4.0",

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,25 @@ chai.use(sinonChai);
 
 
 describe('Connect-modrewrite', function() {
+  describe('query params', function() {
+    it('should keep nested query parameters', function() {
+      var middleware = modRewrite(['/a /b [L]', '/a /c']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/d?foo[0]=bar&foo[1]=baz&q'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.query).to.deep.equal({foo: ['bar','baz'], q: ''});
+    });
+  });
+
   describe('non-match', function() {
     it('should leave the url unrewritten if there is no match', function() {
       var middleware = modRewrite(['/a /b [L]', '/a /c']);


### PR DESCRIPTION
the module is currently using the built in `querystring` module which does not do nested query parsing.

This pull request changes it to use the [`qs` module](https://github.com/visionmedia/node-querystring) which is what is used [internally by express](https://github.com/strongloop/express/blob/b08d4441a4804ed332023efb28a6d3d9b6d902cc/lib/middleware/query.js#L6) so that nested query parsing works again
