### PR TITLE
fix url replacing when matching a partial url

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function _parse(rules) {
       , hostValue = hostSyntax.exec(flags);
 
     return {
-      regexp : typeof parts[2] !== 'undefined' && noCaseSyntax.test(flags) ? new RegExp(parts[0], 'i') : new RegExp(parts[0]),
+      regexp : typeof parts[2] !== 'undefined' && noCaseSyntax.test(flags) ? new RegExp('.*'+parts[0]+'.*', 'i') : new RegExp('.*'+parts[0]+'.*'),
       replace : parts[1],
       inverted : inverted,
       last : lastSyntax.test(flags),

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,93 @@ describe('Connect-modrewrite', function() {
     });
   });
 
+  describe('matching urls', function() {
+    it('it should replace the entire url when doing a partial match', function() {
+      var middleware = modRewrite(['def-(123) /b-$1']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/abc-def-123-456'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/b-123');
+    });
+
+    it('it should match from the beginning when using ^', function() {
+      var middleware = modRewrite(['^/def-(123) /b-$1']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/def-123-xyz'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/b-123');
+    });
+
+    it('it should not match if using ^ and beginning doesnt match', function() {
+      var middleware = modRewrite(['^/def-(123) /b-$1']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/a/def-123-xyz'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/a/def-123-xyz');
+    });
+
+    it('it should match from the end using $', function() {
+      var middleware = modRewrite(['/def-(123)$ /b-$1']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/a/def-123'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/b-123');
+    });
+
+    it('it should not match if using $ and end doesnt match', function() {
+      var middleware = modRewrite(['/def-(123)$ /b-$1']);
+      var req = {
+        connection : { encrypted : false },
+        header : function() {},
+        headers : { host : 'test.com' },
+        url : '/a/def-123-xyz'
+      };
+      var res = {
+        writeHead : function() {},
+        end : function() {}
+      };
+      var next = function() {};
+      middleware(req, res, next);
+      expect(req.url).to.equal('/a/def-123-xyz');
+    });
+  });
+
   describe('non-match', function() {
     it('should leave the url unrewritten if there is no match', function() {
       var middleware = modRewrite(['/a /b [L]', '/a /c']);


### PR DESCRIPTION
Right now if you have a rule defined like `-test /abc` and `req.url = '/this-is-a-test'`
you'll end up with a `req.url` of `/this-is-a/abc`
The expected behavior in this case when using modrewrite is that the url end up being `/abc`
because the `-test` should match the url and the url should get replaced with `/abc`

This error is happening because it does a replace like `'/this-is-a-test'.replace(/-test/, '/abc')` which = `/this-is-a/abc`

This commit adds a `.*` in the beginning and end so the replace ends up being like `'/this-is-a-test'.replace(/.*-test.*/, '/abc')` which correctly = `/abc`

I also added a couple of tests to make sure that url matching works correctly when using `^` and `$`
