### PR TITLE
Updating express and qs deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "qs": "^0.6.6"
+    "qs": "^1.2.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.8.0",
@@ -38,7 +38,7 @@
     "sinon-chai": "~2.5.0",
     "proxyquire": "~0.5.2",
     "jshint-globals": "~0.1.0",
-    "express": "~3.4.8"
+    "express": "~3.16.7"
   },
   "scripts": {
     "test": "./bin/test"


### PR DESCRIPTION
See https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking and https://nodesecurity.io/advisories/qs_dos_memory_exhaustion

I kept the **express** dependency on the latest 3.x branch, which still has the latest **qs** fixes.
