### PR TITLE
Leverage request library for proxied redirect support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+.idea/
 .npm-debug.log
 *.log

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var typeSyntax = /T=([\w|\/]+,?)/;
 var hostSyntax =  /H=([^,]+)/;
 var flagSyntax = /\[([^\]]+)]$/;
 var partsSyntax = /\s+|\t+/g;
-var httpsSyntax = /^https/;
 var querySyntax = /\?(.*)/;
 
 /**
@@ -192,9 +191,11 @@ function _parse(rules) {
 
 function _proxy(rule, metas) {
   var opts = _getRequestOpts(metas.req, rule);
-  request({ url: opts.href, method: opts.method || 'GET', jar: true })
-  .on('response', function(response) {
-    response.headers.via = opts.headers.via;
+  request({
+    url: opts.href,
+    method: opts.method || 'GET',
+    jar: true,
+    headers: opts.headers
   }).on('error', function(response) {
     metas.next(response);
   }).pipe(metas.res);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     }
   ],
   "dependencies": {
-    "qs": "^1.2.2"
+    "qs": "^1.2.2",
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.8.0",

--- a/test/test.js
+++ b/test/test.js
@@ -8,8 +8,7 @@ var modRewrite = require('../')
   , chai = require('chai')
   , expect = require('chai').expect
   , proxyquire = require('proxyquire')
-  , sinonChai = require('sinon-chai')
-  , stream = require('stream');
+  , sinonChai = require('sinon-chai');
 
 /**
  * Plugins.
@@ -362,7 +361,7 @@ describe('Connect-modrewrite', function() {
 
       var requestStub = sinon.stub().returns(requestLibrary);
       var modRewrite = proxyquire('../', { request : requestStub });
-      var requestStreamEndCallback = undefined;
+      var requestStreamEndCallback;
 
       var middleware = modRewrite(['/a http://test1.com/ [P]']);
       var req = {

--- a/test/test.js
+++ b/test/test.js
@@ -353,12 +353,11 @@ describe('Connect-modrewrite', function() {
 
   describe('proxy', function() {
     it('should proxy request whenever proxy flag is set', function() {
-      var onResponseStub = sinon.stub().returns({
+      var request = {
         on: sinon.stub().returns({
           pipe: sinon.stub()
         })
-      });
-      var request = { on: onResponseStub };
+      };
       var requestStub = sinon.stub().returns(request);
       var modRewrite = proxyquire('../', { request : requestStub });
 
@@ -366,18 +365,19 @@ describe('Connect-modrewrite', function() {
       var req = {
         connection : { encrypted : false },
         header : function() {},
-        headers : { host : 'test2.com' },
+        headers : { 'TEST_HEADER' : 'TEST_VALUE' },
         url : '/a',
         method: 'TEST_METHOD',
       };
       var next = function() {};
       middleware(req, {}, next);
-      requestStub.should.have.been.calledOnce;
-      expect(requestStub.args[0][0]).to.eql({ url: 'http://test1.com/', method: 'TEST_METHOD', jar: true });
 
-      var mockResponse = { headers: {} };
-      onResponseStub.args[0][1](mockResponse);
-      expect(mockResponse.headers.via).to.have.string('1.1');
+      requestStub.should.have.been.calledOnce;
+      expect(requestStub.args[0][0].url).to.eql('http://test1.com/');
+      expect(requestStub.args[0][0].method).to.eql('TEST_METHOD');
+      expect(requestStub.args[0][0].jar).to.be.true;
+      expect(requestStub.args[0][0].headers.TEST_HEADER).to.eql('TEST_VALUE');
+      expect(requestStub.args[0][0].headers.via).to.have.string('1.1');
     });
   });
 


### PR DESCRIPTION
This pull request leverages the `request` library for simplified proxy code and support for following redirections in proxied responses.