### PR TITLE
qs 6.3.1 to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-modrewrite",
   "main": "./index.js",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "connect-modrewrite adds modrewrite functionality to connect/express server",
   "author": {
     "name": "Tingan Ho",
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "qs": "^1.2.2"
+    "qs": "^6.3.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.8.0",


### PR DESCRIPTION
A [vulnerability](https://snyk.io/test/github/localnerve/react-pwa-reference) was discovered in `qs` last week. qs 6.3.1 [should address this](https://github.com/ljharb/qs/blob/master/CHANGELOG.md). This PR just updates the dependency and bumps to 0.10.0.